### PR TITLE
Replace ConfigurationHolder for Holders.

### DIFF
--- a/grails-app/taglib/org/geeks/plugins/DisqusTagLib.groovy
+++ b/grails-app/taglib/org/geeks/plugins/DisqusTagLib.groovy
@@ -1,11 +1,11 @@
 package org.geeks.plugins
 
-import org.codehaus.groovy.grails.commons.ConfigurationHolder as CH
+import grails.util.Holders as H
 
 class DisqusTagLib {
   static namespace = "disqus"
   def comments = { attrs ->
-    def settings = CH.config.grails.plugins.disqus
+    def settings = H.config.grails.plugins.disqus
     def shortname = attrs['shortname'] ? attrs['shortname'].toString() : settings.shortname
 
     if(!shortname) {


### PR DESCRIPTION
Since org.codehaus.groovy.grails.commons.ConfigurationHolder was removed in 2.4.X, the plugin doesn't compile on this versions. As this plugin was compiled on 2.0.3 we can add grails.util.Holders instead of the old ConfigurationHolder.
